### PR TITLE
feature/add-item

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   rspec (~> 3.0)

--- a/item.rb
+++ b/item.rb
@@ -1,5 +1,5 @@
 class Item
-  attr_accessor :id, :genre, :author, :label, :publish_date
+  attr_accessor :genre, :author, :label, :publish_date
 
   def initialize(params = {})
     self.class.id_counter = (self.class.id_counter || 0) + 1
@@ -35,6 +35,8 @@ class Item
   end
 
   private
+
+  attr_reader :id, :archived
 
   def can_be_archived?
     Time.now.year - @publish_date.year > 10

--- a/item.rb
+++ b/item.rb
@@ -1,5 +1,42 @@
 class Item
-  def initialize()
-    @mock = []
+  attr_accessor :id, :genre, :author, :label, :publish_date
+
+  def initialize(params = {})
+    self.class.id_counter = (self.class.id_counter || 0) + 1
+    @genre = params[:genre]
+    @author = params[:author]
+    @label = params[:label]
+    @publish_date = (Date.strptime(params[:publish_date], '%d-%m-%Y') if params[:publish_date])
+    private
+    @id = self.class.id_counter
+    @archived = false
+  end
+
+  def move_to_archive
+    @archived = true if can_be_archived?
+  end
+
+  # Method that adds genre and updates the reference in the genre object
+  def add_genre(genre)
+    @genre = genre
+    genre.items.push(self) unless genre.items.include?(self)
+  end
+
+  # Method that adds author and updates the reference in the author object
+  def add_author(author)
+    @author = author
+    author.items.push(self) unless author.items.include?(self)
+  end
+
+  # Method that adds label and updates the reference in the label object
+  def add_label(label)
+    @label = label
+    label.items.push(self) unless label.items.include?(self)
+  end
+
+  private
+
+  def can_be_archived?
+    Time.now.year - @publish_date.year > 10
   end
 end


### PR DESCRIPTION
# Description
This feature fulfills the following requirements:
- [ ] Create an `Item` class in a separate .rb file.
- [ ] All `Item` class properties visible in the diagram should be defined and set up in the constructor method. 

- **_Exception_**: Properties for the 1-to-many relationships should NOT be set in the constructor method. Instead, they should have a custom setter method created.

@ClaudiaRojasSoto 
@francksefu 
@PabloBona 